### PR TITLE
chore: upgrading to Java 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'corretto'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'corretto'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-alpine
+FROM amazoncorretto:25-alpine
 
 RUN mkdir /opt/open-cambio
 COPY build/libs/open-cambio-0.0.2-SNAPSHOT.jar /opt/open-cambio/open-cambio-0.0.2-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -233,11 +233,11 @@ curl http://api.opencambio.org/v1/currencies/USD/rates/latest
 
 ### Karate tests
 ```
-./gradlew test --tests "*karate.*" -Dkarate.env=local
+./gradlew karateTest -Dkarate.env=local
 ```
 
 ```
-./gradlew test --tests "*karate.*" -Dkarate.env=dev
+./gradlew karateTest -Dkarate.env=dev
 ```
 
 ### Running locally

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ version = "0.0.2-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -39,7 +39,7 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("com.intuit.karate:karate-junit5:1.1.0")
+    testImplementation("io.karatelabs:karate-junit5:1.5.2")
 }
 
 tasks.withType<Test> {
@@ -50,6 +50,18 @@ tasks.withType<Test> {
     outputs.upToDateWhen { false }
     systemProperty("karate.options", System.getProperty("karate.options"))
     systemProperty("karate.env", System.getProperty("karate.env"))
+}
+
+tasks.named<Test>("test") {
+    exclude("**/karate/**")
+}
+
+tasks.register<Test>("karateTest") {
+    description = "Runs Karate API tests. Requires the application to be running (use -Dkarate.env=local)."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    include("**/karate/**")
 }
 
 sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Upgrade Java toolchain from 21 to 25 (latest LTS)
- Upgrade Gradle wrapper from 8.14 to 9.4.1 (required for Java 25 runtime support)
- Upgrade Karate from `com.intuit.karate:karate-junit5:1.1.0` to `io.karatelabs:karate-junit5:1.5.2` (new group ID, Java 25 compatible)
- Exclude Karate tests from default `test` task; add dedicated `karateTest` task
- Update Dockerfile base image from `amazoncorretto:21-alpine` to `amazoncorretto:25-alpine`
- Update GitHub Actions workflow to use JDK 25
- Update README with new `karateTest` command

## Test plan

- [x] `./gradlew build` passes with all tests green
- [x] Ran locally with `--spring.profiles.active=local`
- [x] Karate API tests passed: `./gradlew karateTest -Dkarate.env=local`