### PR TITLE
chore: upgrading to spring-boot 4.0.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.5.14"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -26,20 +26,20 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
-    implementation("com.fasterxml.jackson.core:jackson-core")
-    implementation("com.fasterxml.jackson.core:jackson-annotations")
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("org.postgresql:postgresql")
     annotationProcessor("org.projectlombok:lombok")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-restclient-test")
     testImplementation("io.karatelabs:karate-junit5:1.5.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/github/lerocha/opencambio/configuration/CurrencyConfiguration.java
+++ b/src/main/java/com/github/lerocha/opencambio/configuration/CurrencyConfiguration.java
@@ -16,7 +16,9 @@
 
 package com.github.lerocha.opencambio.configuration;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -28,6 +30,11 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 @EnableJpaAuditing
 public class CurrencyConfiguration {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager("currencies", "rates");
+    }
 
     @Bean
     public RestTemplate restTemplate() {

--- a/src/main/java/com/github/lerocha/opencambio/ecb/dto/CurrencyExchangeRate.java
+++ b/src/main/java/com/github/lerocha/opencambio/ecb/dto/CurrencyExchangeRate.java
@@ -16,7 +16,7 @@
 
 package com.github.lerocha.opencambio.ecb.dto;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/github/lerocha/opencambio/ecb/dto/DailyExchangeRate.java
+++ b/src/main/java/com/github/lerocha/opencambio/ecb/dto/DailyExchangeRate.java
@@ -16,8 +16,8 @@
 
 package com.github.lerocha.opencambio.ecb.dto;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/github/lerocha/opencambio/ecb/dto/ExchangeRatesResponse.java
+++ b/src/main/java/com/github/lerocha/opencambio/ecb/dto/ExchangeRatesResponse.java
@@ -16,9 +16,9 @@
 
 package com.github.lerocha.opencambio.ecb.dto;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -30,7 +30,7 @@ import java.util.List;
  */
 @Data
 @NoArgsConstructor
-@JacksonXmlRootElement(namespace = "gesmes", localName = "Envelope")
+@JsonRootName(value = "Envelope", namespace = "gesmes")
 public class ExchangeRatesResponse implements Serializable {
     private static final long serialVersionUID = 6066345143583997388L;
 

--- a/src/main/java/com/github/lerocha/opencambio/ecb/dto/Sender.java
+++ b/src/main/java/com/github/lerocha/opencambio/ecb/dto/Sender.java
@@ -16,7 +16,7 @@
 
 package com.github.lerocha.opencambio.ecb.dto;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/github/lerocha/opencambio/service/CurrencyServiceImpl.java
+++ b/src/main/java/com/github/lerocha/opencambio/service/CurrencyServiceImpl.java
@@ -39,7 +39,6 @@ import org.springframework.util.Assert;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -75,10 +74,8 @@ public class CurrencyServiceImpl implements CurrencyService {
         for (Object[] result : results) {
             String currencyCode = (String) result[0];
             Currency currency = new Currency(currencyCode, java.util.Currency.getInstance(currencyCode).getDisplayName(locale != null ? locale : Locale.US));
-            Date startDate = (Date) result[1];
-            currency.setStartDate(startDate.toLocalDate());
-            Date endDate = (Date) result[2];
-            currency.setEndDate(endDate.toLocalDate());
+            currency.setStartDate((LocalDate) result[1]);
+            currency.setEndDate((LocalDate) result[2]);
             currencies.add(currency);
         }
         log.info("getCurrencies; locale={}; total={}", locale, currencies.size());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,6 @@ spring.jmx:
 
 spring.jackson:
   serialization:
-    WRITE_DATES_AS_TIMESTAMPS: false
     INDENT_OUTPUT: true
   default-property-inclusion: non_null
 

--- a/src/test/java/karate-config.js
+++ b/src/test/java/karate-config.js
@@ -1,7 +1,7 @@
 function karateConfig() {
   const config = {
     local: {
-      url: 'http://localhost:5000',
+      url: 'http://localhost:5001',
     },
     dev: {
       url: 'http://api.opencambio.org',


### PR DESCRIPTION
## Summary

- Upgrade Spring Boot from 3.5.14 to 4.0.6
- Replace `spring-boot-starter-web` with `spring-boot-starter-webmvc` (renamed in Spring Boot 4)
- Add `spring-boot-starter-restclient` (RestTemplate support moved to its own starter)
- Replace `spring-boot-starter-test` with technology-specific test starters (`webmvc-test`, `data-jpa-test`, `restclient-test`)
- Update `springdoc-openapi` from `2.8.13` to `3.0.3` (Spring Boot 4 / Spring Framework 7 compatible)
- Update Jackson XML annotations from `com.fasterxml.jackson` to `tools.jackson` (Jackson 3 package rename)
- Replace deprecated `@JacksonXmlRootElement` with `@JsonRootName` in `ExchangeRatesResponse`
- Update `RestTemplateBuilder` import to `org.springframework.boot.restclient` (moved in Spring Boot 4)
- Add explicit `ConcurrentMapCacheManager` bean (`@EnableCaching` now requires it in Spring Boot 4)
- Remove `spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS` (removed from Jackson 3 — ISO-8601 is now the default)
- Fix `java.sql.Date` cast to `LocalDate` in `CurrencyServiceImpl` (Hibernate 7 now returns `LocalDate` directly from native queries)
- Update Karate local URL to port 5001

## Test plan

- [x] `./gradlew build` passes with all tests green
- [x] Ran locally with `--spring.profiles.active=local`
- [x] Karate API tests passed: `./gradlew karateTest -Dkarate.env=local`